### PR TITLE
Fix a few crashes on bad input in decoder

### DIFF
--- a/src/ulz.hpp
+++ b/src/ulz.hpp
@@ -6,8 +6,8 @@ Written and placed in the public domain by Ilya Muravyov
 
 */
 
-#ifndef __ULZ_HPP
-#define __ULZ_HPP
+#ifndef ULZ_HPP_INCLUDED
+#define ULZ_HPP_INCLUDED
 
 class CULZ
 {
@@ -317,4 +317,4 @@ public:
   }
 };
 
-#endif // __ULZ_HPP
+#endif // ULZ_HPP_INCLUDED

--- a/src/ulz.hpp
+++ b/src/ulz.hpp
@@ -279,7 +279,7 @@ public:
         int run=tag>>5;
         if (run==7)
           run+=DecodeMod(ip);
-        if ((op_end-op)<run) // Overrun check
+        if ((op_end-op)<run || (ip_end-ip)<run) // Overrun check
           return -1;
 
         WildCopy(op, ip, run);

--- a/src/ulz.hpp
+++ b/src/ulz.hpp
@@ -100,7 +100,7 @@ public:
     U32 x=0;
     for (int i=0; i<=28; i+=7)
     {
-      const int c=*p++;
+      const U32 c=*p++;
       x+=c<<i;
       if (c<128)
         break;
@@ -273,10 +273,10 @@ public:
 
     while (ip<ip_end)
     {
-      const int tag=*ip++;
+      const U32 tag=*ip++;
       if (tag>=32)
       {
-        int run=tag>>5;
+        U32 run=tag>>5;
         if (run==7)
           run+=DecodeMod(ip);
         if ((op_end-op)<run || (ip_end-ip)<run) // Overrun check
@@ -289,13 +289,13 @@ public:
           break;
       }
 
-      int len=(tag&15)+MIN_MATCH;
+      U32 len=(tag&15)+MIN_MATCH;
       if (len==(15+MIN_MATCH))
         len+=DecodeMod(ip);
       if ((op_end-op)<len) // Overrun check
         return -1;
 
-      const int dist=((tag&16)<<12)+UnalignedLoad16(ip);
+      const U32 dist=((tag&16)<<12)+UnalignedLoad16(ip);
       ip+=2;
       if ((op-out)<dist) // Range check
         return -1;

--- a/src/ulz.hpp
+++ b/src/ulz.hpp
@@ -279,7 +279,7 @@ public:
         int run=tag>>5;
         if (run==7)
           run+=DecodeMod(ip);
-        if ((op+run)>op_end) // Overrun check
+        if ((op_end-op)<run) // Overrun check
           return -1;
 
         WildCopy(op, ip, run);
@@ -292,14 +292,14 @@ public:
       int len=(tag&15)+MIN_MATCH;
       if (len==(15+MIN_MATCH))
         len+=DecodeMod(ip);
-      if ((op+len)>op_end) // Overrun check
+      if ((op_end-op)<len) // Overrun check
         return -1;
 
       const int dist=((tag&16)<<12)+UnalignedLoad16(ip);
       ip+=2;
-      U8* cp=op-dist;
-      if (cp<out) // Range check
+      if ((op-out)<dist) // Range check
         return -1;
+      U8* cp=op-dist;
 
       if (dist>=4)
       {


### PR DESCRIPTION
I ran the decoder through libFuzzer and found a few issues:
  - Add a check for sufficient input before doing a literal copy
  - The `run` and `len` variables could overflow (when `DecodeMod()` reads 5 bytes), which resulted in negative values that passed the range checks
